### PR TITLE
DF-2391 - Allow codebuild job to invoke lambda in some environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,11 @@ Ensure you add the following permissions to the lambda role
 
 
 []: https://www.terraform.io/docs/providers/aws/r/lambda_function.html
+
+## Codebuild and Integration Testing
+
+If invoking this module within an environment where Integration testing makes sense as part of CI, by setting the "codebuild_can_run_integration_test" argument to true
+ * The codebuild job that accompanies lambda ci is now able to invoke the lambda function
+ * Will know if it's appropriate to perform integration testing in the environment it's running in according to env variable "run_integration_test"
+
+As an example implementation of the codebuild job conditionally running integration tests see https://github.com/PatientPing/d2p_address_lookup_lambda

--- a/README.md
+++ b/README.md
@@ -129,6 +129,6 @@ Ensure you add the following permissions to the lambda role
 
 If invoking this module within an environment where Integration testing makes sense as part of CI, by setting the "codebuild_can_run_integration_test" argument to true
  * The codebuild job that accompanies lambda ci is now able to invoke the lambda function
- * Will know if it's appropriate to perform integration testing in the environment it's running in according to env variable "run_integration_test"
+ * The codebuild job will know if it's appropriate to perform integration testing in the environment it's running in according to env variable "run_integration_test"
 
 As an example implementation of the codebuild job conditionally running integration tests see https://github.com/PatientPing/d2p_address_lookup_lambda

--- a/README.md
+++ b/README.md
@@ -131,4 +131,9 @@ If invoking this module within an environment where Integration testing makes se
  * The codebuild job that accompanies lambda ci is now able to invoke the lambda function
  * The codebuild job will know if it's appropriate to perform integration testing in the environment it's running in according to env variable "run_integration_test"
 
-For an example implementation of a lambda-codebuild job setup to conditionally run integration tests see https://github.com/PatientPing/d2p_address_lookup_lambda
+For an example implementation of a lambda-codebuild job setup to conditionally run integration tests see this buildspec.yml excerpt:
+
+    if [ "$run_integration_test" = true ]; then
+          aws lambda wait function-updated --function-name $lambda_name;
+          aws lambda invoke --function-name $lambda_name --payload file://tests/testEvent.json response.json | jq -e 'has("FunctionError")|not';
+    fi

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Additional arguments:
 | create_empty_layer        | Create an empty lambda layer without the actual code if set to true       | True         |
 | codebuild_image           | Specify Codebuild's [image](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html) | "aws/codebuild/standard:1.0" |
 | privileged_mode           | Run the docker container with [privilege](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)               | False         |
+| codebuild_can_run_integration_test | Specifies whether or not codebuild job can invoke lambda function and is passed through to the job as an env variable (run_integration_test) | False
 
 # CodeBuild
 

--- a/README.md
+++ b/README.md
@@ -131,4 +131,4 @@ If invoking this module within an environment where Integration testing makes se
  * The codebuild job that accompanies lambda ci is now able to invoke the lambda function
  * The codebuild job will know if it's appropriate to perform integration testing in the environment it's running in according to env variable "run_integration_test"
 
-As an example implementation of the codebuild job conditionally running integration tests see https://github.com/PatientPing/d2p_address_lookup_lambda
+For an example implementation of a lambda-codebuild job setup to conditionally run integration tests see https://github.com/PatientPing/d2p_address_lookup_lambda

--- a/lambda_function/ci.tf
+++ b/lambda_function/ci.tf
@@ -49,6 +49,7 @@ resource "aws_iam_role_policy" "codebuild" {
         "lambda:UpdateFunctionCode",
         "lambda:ListVersionsByFunction",
         "lambda:UpdateAlias"
+        "${var.codebuild_can_invoke_lambda ? ",lambda:InvokeFunction" : ""}"
       ]
     }
   ]

--- a/lambda_function/ci.tf
+++ b/lambda_function/ci.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "policy" {
     content {
       effect = "Allow"
       resources = [aws_lambda_function.lambda.arn]
-      actions = ["lambda:InvokeFunction"]
+      actions = ["lambda:InvokeFunction", "lambda:GetFunctionConfiguration"]
     }
   }
 

--- a/lambda_function/ci.tf
+++ b/lambda_function/ci.tf
@@ -74,7 +74,10 @@ resource "aws_codebuild_project" "lambda" {
     image                       = "aws/codebuild/standard:4.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
-    run_integration_test        = var.codebuild_can_run_integration_test
+    environment_variable {
+      name = "run_integration_test"
+      value = var.codebuild_can_run_integration_test
+    }
   }
 
   source {

--- a/lambda_function/ci.tf
+++ b/lambda_function/ci.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "policy" {
     ]
   }
   dynamic "statement" {
-    for_each = var.codebuild_can_invoke_lambda ? ["allow_invoke"] : []
+    for_each = var.codebuild_can_run_integration_test ? ["allow_invoke"] : []
     content {
       effect = "Allow"
       resources = [aws_lambda_function.lambda.arn]
@@ -74,6 +74,7 @@ resource "aws_codebuild_project" "lambda" {
     image                       = "aws/codebuild/standard:4.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
+    run_integration_test        = var.codebuild_can_run_integration_test
   }
 
   source {

--- a/lambda_function/variables.tf
+++ b/lambda_function/variables.tf
@@ -119,7 +119,7 @@ variable "codebuild_credential_arn" {
   default = ""
 }
 
-variable "codebuild_can_invoke_lambda" {
+variable "codebuild_can_run_integration_test" {
   type    = bool
   default = false
 }

--- a/lambda_function/variables.tf
+++ b/lambda_function/variables.tf
@@ -119,6 +119,11 @@ variable "codebuild_credential_arn" {
   default = ""
 }
 
+variable "codebuild_can_invoke_lambda" {
+  type    = bool
+  default = false
+}
+
 variable "build_timeout" {
   type    = string
   default = "60"


### PR DESCRIPTION
- Add an optional variable that defaults to false and if true gives the codebuild job for the lambda function the ability to invoke the lambda function (for integration testing purposes)