### PR TITLE
Remove deprecated Auth block from codebuild jobs

### DIFF
--- a/lambda_function/ci.tf
+++ b/lambda_function/ci.tf
@@ -89,10 +89,6 @@ resource "aws_codebuild_project" "lambda" {
     location        = var.github_url
     git_clone_depth = 1
 
-    auth {
-      type     = "OAUTH"
-      resource = var.codebuild_credential_arn == "" ? "arn:aws:codebuild:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:token/github" : var.codebuild_credential_arn
-    }
   }
 }
 

--- a/lambda_layer/ci.tf
+++ b/lambda_layer/ci.tf
@@ -85,10 +85,6 @@ resource "aws_codebuild_project" "lambda" {
     location        = var.github_url
     git_clone_depth = 1
 
-    auth {
-      type     = "OAUTH"
-      resource = var.codebuild_credential_arn == "" ? "arn:aws:codebuild:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:token/github" : var.codebuild_credential_arn
-    }
   }
 }
 


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0

The release above for the aws provider introduced a number of breaking changes. This PR is to address:
`resource/aws_codebuild_project: The secondary_sources.auth and source.auth attributes have been removed`

Auth is already handled by a `aws_codebuild_source_credential` resource created by foundation in deployed environments. There can be only one per account, and it does not need to be specifically passed to codebuild jobs, so there is no replacement necessary in this module. 
