### PR TITLE
PNGDAT-1002 Create codebuild infra to run unit tests before merging lambda layers and functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,14 @@ For an example implementation of a lambda-codebuild job setup to conditionally r
           aws lambda wait function-updated --function-name $lambda_name;
           aws lambda invoke --function-name $lambda_name --payload file://tests/testEvent.json response.json | jq -e 'has("FunctionError")|not';
     fi
+
+## Codebuild and Unit Testing
+
+If invoking this module within an environment where unit testing makes sense, by setting the "codebuild_can_run_unit_test" argument to true
+* A new codebuild job, its associated webhooks, and the necessary resources will be created to run unit tests
+* This new codebuild can be created for both lambda functions and layers
+* This codebuild job gets triggered automatically by certain events in lambda functions and layers github repo, such as a pull request or pull request update
+* The details on this codebuild job can be found in the "unit_test_trigger.tf" file in the lambda_function and lambda_layer directories
+* Following things need to be done for proper setup:
+  * Need to make sure that codebuild_can_run_unit_test is set to true in the lambda_function or lambda_layer module
+  * To trigger this codebuild, you need to add buildspec-tests.yml in the branch you are creating the PR from

--- a/lambda_function/unit_test_trigger.tf
+++ b/lambda_function/unit_test_trigger.tf
@@ -1,0 +1,93 @@
+resource "aws_iam_role" "unit_test_codebuild_role" {
+  count = var.create_codebuild_to_run_unit_test == true ? 1 : 0
+  name  = "${var.function_name}_ci_test"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codebuild.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "unit_test_codebuild" {
+  count = var.create_codebuild_to_run_unit_test == true ? 1 : 0
+  name  = "${var.function_name}_ci_test"
+  role  = aws_iam_role.unit_test_codebuild_role[0].name
+
+  policy = jsonencode({
+    Version : "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow"
+        Resource = [
+          "arn:aws:codebuild:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:report-group/${aws_codebuild_project.unit_test_codebuild[0].name}-*"
+        ]
+        Action = [
+          "codebuild:CreateReportGroup",
+          "codebuild:CreateReport",
+          "codebuild:UpdateReport",
+          "codebuild:BatchPutTestCases",
+          "codebuild:BatchPutCodeCoverages"
+        ]
+      },
+      {
+        Effect   = "Allow",
+        Resource = [
+          "*"
+        ],
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+      }
+    ]
+  })
+}
+
+
+resource "aws_codebuild_project" "unit_test_codebuild" {
+  count        = var.create_codebuild_to_run_unit_test == true ? 1 : 0
+  name         = "${var.function_name}_ci_test"
+  service_role = aws_iam_role.unit_test_codebuild_role[0].arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = var.codebuild_image
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = var.privileged_mode
+  }
+
+  source {
+    type            = "GITHUB"
+    location        = var.github_url
+    git_clone_depth = 2
+    buildspec       = "buildspec-tests.yml"
+  }
+}
+
+resource "aws_codebuild_webhook" "unit_test_codebuild" {
+  count        = var.create_codebuild_to_run_unit_test == true ? 1 : 0
+  project_name = aws_codebuild_project.unit_test_codebuild[0].name
+
+  filter_group {
+    filter {
+      type    = "EVENT"
+      pattern = "PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED, PULL_REQUEST_REOPENED"
+    }
+  }
+}

--- a/lambda_function/variables.tf
+++ b/lambda_function/variables.tf
@@ -115,6 +115,16 @@ variable "github_url" {
   default = ""
 }
 
+variable "codebuild_image" {
+  type    = string
+  default = "aws/codebuild/standard:4.0"
+}
+
+variable "privileged_mode" {
+  type    = string
+  default = false
+}
+
 variable "layers" {
   type    = list(string)
   default = []
@@ -136,11 +146,17 @@ variable "build_timeout" {
 }
 
 variable "git_branch" {
-  type = string
+  type    = string
   default = "master"
 }
 
 variable "ephemeral_storage" {
-  type = number
+  type    = number
   default = 512
+}
+
+variable "create_codebuild_to_run_unit_test" {
+  type        = bool
+  default     = false
+  description = "If true, will create codebuild and all the resources for running unit tests"
 }

--- a/lambda_layer/unit_test_trigger.tf
+++ b/lambda_layer/unit_test_trigger.tf
@@ -1,0 +1,93 @@
+resource "aws_iam_role" "unit_test_codebuild_role" {
+  count = var.create_codebuild_to_run_unit_test == true ? 1 : 0
+  name  = "${var.layer_name}_ci_test"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codebuild.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "unit_test_codebuild" {
+  count = var.create_codebuild_to_run_unit_test == true ? 1 : 0
+  name  = "${var.layer_name}_ci_test"
+  role  = aws_iam_role.unit_test_codebuild_role[0].name
+
+  policy = jsonencode({
+    Version : "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow"
+        Resource = [
+          "arn:aws:codebuild:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:report-group/${aws_codebuild_project.unit_test_codebuild[0].name}-*"
+        ]
+        Action = [
+          "codebuild:CreateReportGroup",
+          "codebuild:CreateReport",
+          "codebuild:UpdateReport",
+          "codebuild:BatchPutTestCases",
+          "codebuild:BatchPutCodeCoverages"
+        ]
+      },
+      {
+        Effect   = "Allow",
+        Resource = [
+          "*"
+        ],
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+      }
+    ]
+  })
+}
+
+
+resource "aws_codebuild_project" "unit_test_codebuild" {
+  count        = var.create_codebuild_to_run_unit_test == true ? 1 : 0
+  name         = "${var.layer_name}_ci_test"
+  service_role = aws_iam_role.unit_test_codebuild_role[0].arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = var.codebuild_image
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = var.privileged_mode
+  }
+
+  source {
+    type            = "GITHUB"
+    location        = var.github_url
+    git_clone_depth = 2
+    buildspec       = "buildspec-tests.yml"
+  }
+}
+
+resource "aws_codebuild_webhook" "unit_test_codebuild" {
+  count        = var.create_codebuild_to_run_unit_test == true ? 1 : 0
+  project_name = aws_codebuild_project.unit_test_codebuild[0].name
+
+  filter_group {
+    filter {
+      type    = "EVENT"
+      pattern = "PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED, PULL_REQUEST_REOPENED"
+    }
+  }
+}

--- a/lambda_layer/variables.tf
+++ b/lambda_layer/variables.tf
@@ -57,3 +57,9 @@ variable "git_branch" {
   type    = string
   default = "master"
 }
+
+variable "create_codebuild_to_run_unit_test" {
+  type        = bool
+  default     = false
+  description = "If true, will create codebuild and all the resources for running unit tests"
+}


### PR DESCRIPTION
**Link to ticket:**
https://hbuco.atlassian.net/browse/PNGDAT-1002

**Description:**
Creating the a common codebuild infra for running unit tests before merging the lambda function and lambda layer code. This test codebuild infra should be optional and be only created only if we pass the variable create_unit_test_resources value as true. Main reason we are adding this in common lambda code is to avoid a lot of code duplication and to set a standard way for performing this unit tests.