### PR TITLE
CAB-4856: Apply master-branch kno2-discharge-summary Terraform and check for drift

### DIFF
--- a/lambda_function/lambda_function.tf
+++ b/lambda_function/lambda_function.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_log_group" "lambda_log_group" {
 
 resource "aws_cloudwatch_log_subscription_filter" "example_subscription_filter" {
   count           = var.ship_logs_to_sumo ? 1 : 0
-  name            = "${var.function_name}_subscription_filter"
+  name            = coalesce(var.subscription_filter_name, "${var.function_name}_subscription_filter")
   log_group_name  = aws_cloudwatch_log_group.lambda_log_group.name
   destination_arn = "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:SumoCWLogsLambda"
   filter_pattern  = ""

--- a/lambda_function/variables.tf
+++ b/lambda_function/variables.tf
@@ -184,6 +184,12 @@ variable "log_skip_destroy" {
   description = "If true, the log group will not be destroyed when the lambda is destroyed"
 }
 
+variable "subscription_filter_name" {
+  type        = string
+  default     = null
+  description = "Optional override for the CloudWatch Logs subscription filter name"
+}
+
 variable "ship_logs_to_sumo" {
   type        = bool
   default     = false


### PR DESCRIPTION
**Link to Ticket:** https://hbuco.atlassian.net/browse/CAB-4856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration to customize the CloudWatch Logs subscription filter name for Lambda setups. You can now provide a specific name; if omitted, the system defaults to a function-based name, preserving existing behavior.
  * Introduced a new variable to set this name explicitly, offering better alignment with naming conventions and organizational standards while remaining fully backward compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->