### PR TITLE
Revert "CAB-4856: Apply master-branch kno2-discharge-summary Terraform and check for drift"

### DIFF
--- a/lambda_function/lambda_function.tf
+++ b/lambda_function/lambda_function.tf
@@ -3,7 +3,6 @@ locals {
 }
 
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
-  count             = var.manage_log_group ? 1 : 0
   name              = local.log_group_name
   retention_in_days = var.log_retention_in_days
   tags              = var.log_tags == {} ? var.tags : var.log_tags
@@ -13,7 +12,7 @@ resource "aws_cloudwatch_log_group" "lambda_log_group" {
 resource "aws_cloudwatch_log_subscription_filter" "example_subscription_filter" {
   count           = var.ship_logs_to_sumo ? 1 : 0
   name            = coalesce(var.subscription_filter_name, "${var.function_name}_subscription_filter")
-  log_group_name  = var.manage_log_group ? aws_cloudwatch_log_group.lambda_log_group[0].name : local.log_group_name
+  log_group_name  = aws_cloudwatch_log_group.lambda_log_group.name
   destination_arn = "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:SumoCWLogsLambda"
   filter_pattern  = ""
 }

--- a/lambda_function/variables.tf
+++ b/lambda_function/variables.tf
@@ -201,8 +201,3 @@ variable "log_tags" {
   default     = {}
   description = "Tags to apply to the log group. Defaults to the same tags as the lambda function if nothing is passed in."
 }
-
-variable "manage_log_group" {
-  type    = bool
-  default = true
-}


### PR DESCRIPTION
Reverts PatientPing/terraform-aws-lambda#38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified logging setup by always provisioning the log group and using direct references, reducing configuration complexity.
* **Chores**
  * Removed the obsolete option to toggle log group management.
* **Impact**
  * More consistent and reliable logging is enabled by default; no user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->