### PR TITLE
PNGDAT-3777 add lambda provisioned concurrency support

### DIFF
--- a/lambda_function/lambda_function.tf
+++ b/lambda_function/lambda_function.tf
@@ -50,3 +50,20 @@ resource "aws_lambda_function" "lambda" {
     ]
   }
 }
+
+resource "aws_lambda_alias" "lambda" {
+  count = var.publish && var.provisioned_concurrent_executions > 0 ? 1 : 0
+
+  name             = var.lambda_alias_name
+  description      = "Provisioned concurrency alias for ${var.function_name}"
+  function_name    = aws_lambda_function.lambda.function_name
+  function_version = aws_lambda_function.lambda.version
+}
+
+resource "aws_lambda_provisioned_concurrency_config" "lambda" {
+  count = var.publish && var.provisioned_concurrent_executions > 0 ? 1 : 0
+
+  function_name                     = aws_lambda_function.lambda.function_name
+  provisioned_concurrent_executions = var.provisioned_concurrent_executions
+  qualifier                         = aws_lambda_alias.lambda[0].name
+}

--- a/lambda_function/outputs.tf
+++ b/lambda_function/outputs.tf
@@ -14,6 +14,26 @@ output "invoke_arn" {
   value = aws_lambda_function.lambda.invoke_arn
 }
 
+output "version" {
+  value = aws_lambda_function.lambda.version
+}
+
+output "qualified_arn" {
+  value = aws_lambda_function.lambda.qualified_arn
+}
+
+output "alias_name" {
+  value = try(aws_lambda_alias.lambda[0].name, null)
+}
+
+output "alias_arn" {
+  value = try(aws_lambda_alias.lambda[0].arn, null)
+}
+
+output "alias_invoke_arn" {
+  value = try(aws_lambda_alias.lambda[0].invoke_arn, null)
+}
+
 output "codebuild_role" {
   value = aws_iam_role.codebuild
 }

--- a/lambda_function/variables.tf
+++ b/lambda_function/variables.tf
@@ -33,6 +33,11 @@ variable "publish" {
   default = false
 }
 
+variable "lambda_alias_name" {
+  type    = string
+  default = "live"
+}
+
 variable "handler" {
   type = string
 }
@@ -108,6 +113,11 @@ variable "create_empty_function" {
 
 variable "reserved_concurrent_executions" {
   default = "-1"
+}
+
+variable "provisioned_concurrent_executions" {
+  type    = number
+  default = 0
 }
 
 variable "github_url" {


### PR DESCRIPTION
## Summary\n- add optional alias and provisioned concurrency support to the shared lambda module\n- expose alias/version outputs so callers can target the provisioned alias cleanly\n\n## Verification\n- terraform fmt on changed files\n- terraform init completed in the module worktree\n- terraform validate was attempted but is blocked in this environment by a local provider/plugin schema error unrelated to the edited resources\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Lambda alias support with customizable alias names (default: "live") for improved version management
  * Enabled provisioned concurrency configuration for Lambda functions to optimize performance and reduce cold starts
  * New outputs now expose Lambda versioning and alias details, including qualified ARN and invoke ARN

<!-- end of auto-generated comment: release notes by coderabbit.ai -->