### PR TITLE
AI-3190: honor docker_build_dir in CodeBuild buildspec for subdir builds

### DIFF
--- a/lambda_function/ci.tf
+++ b/lambda_function/ci.tf
@@ -124,7 +124,7 @@ resource "aws_codebuild_project" "lambda" {
     type            = "GITHUB"
     location        = var.github_url
     git_clone_depth = 1
-    buildspec       = var.use_docker ? templatefile("${path.module}/docker_buildspec.yml", {gh_token = var.github_token_path}) : "buildspec.yml"
+    buildspec       = var.use_docker ? templatefile("${path.module}/docker_buildspec.yml", {gh_token = var.github_token_path, docker_build_dir = var.docker_build_dir}) : "buildspec.yml"
   }
 }
 

--- a/lambda_function/docker_buildspec.yml
+++ b/lambda_function/docker_buildspec.yml
@@ -10,6 +10,6 @@ phases:
       - ACCT_ID=$(aws sts get-caller-identity --query "Account" --output text)
       - DOCKER_URI="$${ACCT_ID}.dkr.ecr.us-east-1.amazonaws.com"
       - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $${DOCKER_URI}
-      - docker build --platform=linux/amd64 --provenance=false -t $${DOCKER_URI}/$lambda_function_name . --build-arg GITHUB_TOKEN=$GITHUB_TOKEN --build-arg GITHUB_SHA=$CODEBUILD_RESOLVED_SOURCE_VERSION
+      - docker build --platform=linux/amd64 --provenance=false -t $${DOCKER_URI}/$lambda_function_name "${docker_build_dir}" --build-arg GITHUB_TOKEN=$GITHUB_TOKEN --build-arg GITHUB_SHA=$CODEBUILD_RESOLVED_SOURCE_VERSION
       - docker push $${DOCKER_URI}/$lambda_function_name
       - aws lambda update-function-code --function-name "$lambda_function_name" --image-uri $${DOCKER_URI}/$lambda_function_name:latest


### PR DESCRIPTION
## Summary

Lets the CodeBuild path build a Lambda from a subdirectory of the cloned repo (e.g. `lambdas/<group>/<name>/`), so monorepo-sourced lambdas can deploy via the sandbox (`directly_build_lambdas = false`) environment.

## Background

The module has two build paths, selected by `direct_build`:

- **Mode A — `direct_build = true` (careco: prod/qa/int/dev):** builds locally via `docker_build.sh.tpl`, which **already** builds from `docker_build_dir` (`docker build … "$CLONE_DIR/${docker_build_dir}"`). No change needed here — `form_token_service` already uses this to build a subdir of a monorepo.
- **Mode B — `direct_build = false` (analytics sandbox):** builds in CodeBuild via `docker_buildspec.yml`, which **hardcoded the build context to `.`** and ignored `docker_build_dir`. This was the only gap.

## Change (2 lines)

- `lambda_function/ci.tf` — pass the existing `docker_build_dir` var into the buildspec `templatefile(...)`.
- `lambda_function/docker_buildspec.yml` — `docker build … "${docker_build_dir}"` instead of a hardcoded `.`.

No new variables. `docker_build_dir` already exists and defaults to `"."`, so all ~50 existing lambdas are unchanged; a migrated lambda opts in with `docker_build_dir = "lambdas/<group>/<name>"` — the same knob Mode A already uses.

## Verification

`tofu validate` → "the configuration is valid" (pre-existing provider deprecation warnings only).

Closes AI-3190.