### PR TITLE
AI-3507: fetch Sumo extension into the docker build context

### DIFF
--- a/lambda_function/docker_build.sh.tpl
+++ b/lambda_function/docker_build.sh.tpl
@@ -9,7 +9,12 @@ CLONE_DIR=$(mktemp -d)
 git clone "https://$${GITHUB_TOKEN}@${git_host}" "$${CLONE_DIR}"
 cd "$${CLONE_DIR}"
 git checkout "${git_commit_sha}"
-wget https://github.com/SumoLogic/sumologic-lambda-extensions/releases/latest/download/sumologic-extension-amd64.tar.gz
+# Fetch the Sumo extension into the Docker build context (the build dir), not the
+# clone root, so a subdirectory build context (docker_build_dir set for monorepo
+# lambdas) still contains the tarball for the Dockerfile's
+# `ADD sumologic-extension-amd64.tar.gz*`. docker_build_dir defaults to "." (repo
+# root) for single-repo lambdas, so their build context is unchanged.
+wget -P "$${CLONE_DIR}/${docker_build_dir}" https://github.com/SumoLogic/sumologic-lambda-extensions/releases/latest/download/sumologic-extension-amd64.tar.gz
 # Build
 docker build \
   --platform linux/amd64 \


### PR DESCRIPTION
## Summary

Fixes the Sumo Logic sidecar for **subdirectory builds** (monorepo-migrated lambdas).

The `direct_build` path (`lambda_function/docker_build.sh.tpl`) `wget`s `sumologic-extension-amd64.tar.gz` into the **clone root**, then runs `docker build` against `$CLONE_DIR/${docker_build_dir}`. For a lambda that sets `docker_build_dir` to a subdirectory (e.g. `lambdas/orchestration/hitl_notify_lambda`), the tarball lands **outside** the build context, so the Dockerfile's `ADD sumologic-extension-amd64.tar.gz*` matches nothing and the guarded copy makes it a **silent no-op** — the Sumo extension is never installed and the lambda ships no logs to Sumo.

## Change

`wget -P "$CLONE_DIR/${docker_build_dir}"` so the tarball is always inside the Docker build context.

**Backward compatible:** `docker_build_dir` defaults to `.` for single-repo lambdas, so `$CLONE_DIR/.` == clone root — their build context is unchanged.

## Context

Part of **AI-3507** (prove Sumo works on monorepo-migrated lambdas). Companion PRs:
- `automated-transitions#<hitl_notify sidecar>` — adds the sidecar block to the pilot lambda's Dockerfile.
- `tcm_ai_orchestration_engine` — will bump the migrated modules' `source` ref to this branch's new tip.

## Verification

After the engine repoints and deploys to careco **int**, `hitl_notify` rebuilds from its subdir with the tarball now in context; confirm delivery in Sumo:
```
"tcm-int-hitl-notify" | count by _sourceCategory, _sourceName, _sourceHost
```