### PR TITLE
AI-3522: add create_webhook toggle (disable per-lambda webhooks for monorepo builds)

### DIFF
--- a/lambda_function/ci.tf
+++ b/lambda_function/ci.tf
@@ -129,7 +129,7 @@ resource "aws_codebuild_project" "lambda" {
 }
 
 resource "aws_codebuild_webhook" "lambda" {
-  count = var.github_url != "" && !var.direct_build ? 1 : 0
+  count = var.github_url != "" && !var.direct_build && var.create_webhook ? 1 : 0
 
   project_name = aws_codebuild_project.lambda[0].name
 

--- a/lambda_function/variables.tf
+++ b/lambda_function/variables.tf
@@ -213,6 +213,12 @@ variable "direct_build" {
   description = "Enable Terraform-native Docker build during apply. When false, existing CodeBuild pattern is used."
 }
 
+variable "create_webhook" {
+  type        = bool
+  default     = true
+  description = "Register a CodeBuild GitHub PUSH webhook for this lambda. Set false for monorepo-sourced builds: every lambda's webhook targets the same repo and GitHub caps webhooks at ~20/repo, so per-lambda webhooks don't scale there (the monorepo deploy is driven by the pipeline / tofu apply instead). See AI-3522."
+}
+
 variable "git_commit_sha" {
   type        = string
   default     = ""


### PR DESCRIPTION
## Summary

Adds a `create_webhook` bool variable (default `true` — unchanged behavior) and gates `aws_codebuild_webhook.lambda` on it:

```
count = var.github_url != "" && !var.direct_build && var.create_webhook ? 1 : 0
```

## Why

Per-lambda CodeBuild **PUSH webhooks don't scale for monorepo-sourced builds**. Every migrated lambda's webhook targets the same repo (`automated-transitions`), and GitHub caps webhooks at ~20/repo — so bringing the monorepo lambdas up hits `OAuthProviderException: GitHub webhook limit reached` (observed deploying engine v1.6.6 to analytics-sandbox: 19 created, then failures). Monorepo deploys are driven by the pipeline / `tofu apply`, not per-lambda push webhooks, so callers can now set `create_webhook = false` for those.

Default `true` keeps existing (own-repo) lambdas' webhooks unchanged.

Branched off `c6710ff` (the ref the engine currently pins). Consumed by an engine change that bumps the migrated blocks' module ref to this commit and passes `create_webhook = false`. Stopgap under AI-3522; long-term a single shared repo webhook with path filtering.